### PR TITLE
Fix blank screen with filament sensor enabled

### DIFF
--- a/A10D_marlin1.1.8/Marlin/Conditionals_LCD.h
+++ b/A10D_marlin1.1.8/Marlin/Conditionals_LCD.h
@@ -28,6 +28,9 @@
 #ifndef CONDITIONALS_LCD_H // Get the LCD defines which are needed first
 #define CONDITIONALS_LCD_H
 
+  // Geeetech doesn't use this
+  #undef FILAMENT_RUNOUT_SENSOR
+
   #define LCD_HAS_DIRECTIONAL_BUTTONS (BUTTON_EXISTS(UP) || BUTTON_EXISTS(DWN) || BUTTON_EXISTS(LFT) || BUTTON_EXISTS(RT))
 
   #if ENABLED(CARTESIO_UI)

--- a/A10D_marlin1.1.8/Marlin/stepper.cpp
+++ b/A10D_marlin1.1.8/Marlin/stepper.cpp
@@ -408,11 +408,13 @@ ISR(TIMER1_COMPA_vect) {
     powerloss.pos_t = card.getStatus();
     powerloss.T0_t = thermalManager.degTargetHotend(0) + 0.5;
     powerloss.B_t = thermalManager.degTargetBed() + 0.5;
-    #if ENABLED(BLTOUCH)
-      powerloss.recovery = Rec_Idle;
-    #else
-      powerloss.recovery = Rec_Outage;
-    #endif
+    powerloss.recovery =
+      #if ENABLED(BLTOUCH)
+        Rec_Idle
+      #else
+        Rec_Outage
+      #endif
+    ;
     //settings.save();
     (void)settings.poweroff_save();
     settings.load();

--- a/A10D_marlin1.1.8/Marlin/stepper.cpp
+++ b/A10D_marlin1.1.8/Marlin/stepper.cpp
@@ -381,8 +381,7 @@ ISR(TIMER1_COMPA_vect) {
   //if (READ(FIL_RUNOUT_PIN) && powerloss.P_file_name[0] && powerloss.recovery == Rec_Idle && print_job_timer.isRunning()) {
   if (filament_runout_enabled) {
     if ( (READ(FIL_RUNOUT_PIN) || READ(FIL_RUNOUT2_PIN))
-      && ((powerloss.P_file_name[0] && powerloss.recovery == Rec_Idle) && print_job_timer.isRunning())
-      || !test
+      && ((powerloss.P_file_name[0] && powerloss.recovery == Rec_Idle && print_job_timer.isRunning()) || !test)
     ) {
       test = true;
       //buzzer.tone(400, 5000);

--- a/A10M_marlin1.1.8/Marlin/Conditionals_LCD.h
+++ b/A10M_marlin1.1.8/Marlin/Conditionals_LCD.h
@@ -28,6 +28,9 @@
 #ifndef CONDITIONALS_LCD_H // Get the LCD defines which are needed first
 #define CONDITIONALS_LCD_H
 
+  // Geeetech doesn't use this
+  #undef FILAMENT_RUNOUT_SENSOR
+
   #define LCD_HAS_DIRECTIONAL_BUTTONS (BUTTON_EXISTS(UP) || BUTTON_EXISTS(DWN) || BUTTON_EXISTS(LFT) || BUTTON_EXISTS(RT))
 
   #if ENABLED(CARTESIO_UI)

--- a/A10M_marlin1.1.8/Marlin/stepper.cpp
+++ b/A10M_marlin1.1.8/Marlin/stepper.cpp
@@ -410,11 +410,13 @@ ISR(TIMER1_COMPA_vect) {
       powerloss.pos_t = card.getStatus();
       powerloss.T0_t = thermalManager.degTargetHotend(0) + 0.5;
       powerloss.B_t = thermalManager.degTargetBed() + 0.5;
-      #if ENABLED(BLTOUCH)
-        powerloss.recovery = Rec_Idle;
-      #else
-        powerloss.recovery = Rec_Outage;
-      #endif
+      powerloss.recovery =
+        #if ENABLED(BLTOUCH)
+          Rec_Idle
+        #else
+          Rec_Outage
+        #endif
+      ;
       //settings.save();
       (void)settings.poweroff_save();
       settings.load();

--- a/A10M_marlin1.1.8/Marlin/stepper.cpp
+++ b/A10M_marlin1.1.8/Marlin/stepper.cpp
@@ -381,8 +381,7 @@ ISR(TIMER1_COMPA_vect) {
   //if (READ(FIL_RUNOUT_PIN) && powerloss.P_file_name[0] && powerloss.recovery == Rec_Idle && print_job_timer.isRunning()) {
   if (filament_runout_enabled) {
     if ( (READ(FIL_RUNOUT_PIN) || READ(FIL_RUNOUT2_PIN))
-      && ((powerloss.P_file_name[0] && powerloss.recovery == Rec_Idle) && print_job_timer.isRunning())
-      || !test
+      && ((powerloss.P_file_name[0] && powerloss.recovery == Rec_Idle && print_job_timer.isRunning()) || !test)
     ) {
       test = true;
       //buzzer.tone(400, 5000);

--- a/A10_marlin1.1.8/Marlin/Conditionals_LCD.h
+++ b/A10_marlin1.1.8/Marlin/Conditionals_LCD.h
@@ -28,6 +28,9 @@
 #ifndef CONDITIONALS_LCD_H // Get the LCD defines which are needed first
 #define CONDITIONALS_LCD_H
 
+  // Geeetech doesn't use this
+  #undef FILAMENT_RUNOUT_SENSOR
+
   #define LCD_HAS_DIRECTIONAL_BUTTONS (BUTTON_EXISTS(UP) || BUTTON_EXISTS(DWN) || BUTTON_EXISTS(LFT) || BUTTON_EXISTS(RT))
 
   #if ENABLED(CARTESIO_UI)

--- a/A10_marlin1.1.8/Marlin/stepper.cpp
+++ b/A10_marlin1.1.8/Marlin/stepper.cpp
@@ -408,11 +408,13 @@ ISR(TIMER1_COMPA_vect) {
     powerloss.pos_t = card.getStatus();
     powerloss.T0_t = thermalManager.degTargetHotend(0) + 0.5;
     powerloss.B_t = thermalManager.degTargetBed() + 0.5;
-    #if ENABLED(BLTOUCH)
-      powerloss.recovery = Rec_Idle;
-    #else
-      powerloss.recovery = Rec_Outage;
-    #endif
+    powerloss.recovery =
+      #if ENABLED(BLTOUCH)
+        Rec_Idle
+      #else
+        Rec_Outage
+      #endif
+    ;
     //settings.save();
     (void)settings.poweroff_save();
     settings.load();

--- a/A10_marlin1.1.8/Marlin/stepper.cpp
+++ b/A10_marlin1.1.8/Marlin/stepper.cpp
@@ -381,8 +381,7 @@ ISR(TIMER1_COMPA_vect) {
   //if (READ(FIL_RUNOUT_PIN) && powerloss.P_file_name[0] && powerloss.recovery == Rec_Idle && print_job_timer.isRunning()) {
   if (filament_runout_enabled) {
     if ( (READ(FIL_RUNOUT_PIN) || READ(FIL_RUNOUT2_PIN))
-      && ((powerloss.P_file_name[0] && powerloss.recovery == Rec_Idle) && print_job_timer.isRunning())
-      || !test
+      && ((powerloss.P_file_name[0] && powerloss.recovery == Rec_Idle && print_job_timer.isRunning()) || !test)
     ) {
       test = true;
       //buzzer.tone(400, 5000);

--- a/A20M_Marlin-1.1.x12864/Marlin/Conditionals_LCD.h
+++ b/A20M_Marlin-1.1.x12864/Marlin/Conditionals_LCD.h
@@ -28,6 +28,9 @@
 #ifndef CONDITIONALS_LCD_H // Get the LCD defines which are needed first
 #define CONDITIONALS_LCD_H
 
+  // Geeetech doesn't use this
+  #undef FILAMENT_RUNOUT_SENSOR
+
   #define LCD_HAS_DIRECTIONAL_BUTTONS (BUTTON_EXISTS(UP) || BUTTON_EXISTS(DWN) || BUTTON_EXISTS(LFT) || BUTTON_EXISTS(RT))
 
   #if ENABLED(CARTESIO_UI)

--- a/A20M_Marlin-1.1.x12864/Marlin/stepper.cpp
+++ b/A20M_Marlin-1.1.x12864/Marlin/stepper.cpp
@@ -410,11 +410,13 @@ ISR(TIMER1_COMPA_vect) {
       powerloss.pos_t = card.getStatus();
       powerloss.T0_t = thermalManager.degTargetHotend(0) + 0.5;
       powerloss.B_t = thermalManager.degTargetBed() + 0.5;
-      #if ENABLED(BLTOUCH)
-        powerloss.recovery = Rec_Idle;
-      #else
-        powerloss.recovery = Rec_Outage;
-      #endif
+      powerloss.recovery =
+        #if ENABLED(BLTOUCH)
+          Rec_Idle
+        #else
+          Rec_Outage
+        #endif
+      ;
       //settings.save();
       (void)settings.poweroff_save();
       settings.load();

--- a/A20M_Marlin-1.1.x12864/Marlin/stepper.cpp
+++ b/A20M_Marlin-1.1.x12864/Marlin/stepper.cpp
@@ -381,8 +381,7 @@ ISR(TIMER1_COMPA_vect) {
   //if (READ(FIL_RUNOUT_PIN) && powerloss.P_file_name[0] && powerloss.recovery == Rec_Idle && print_job_timer.isRunning()) {
   if (filament_runout_enabled) {
     if ( (READ(FIL_RUNOUT_PIN) || READ(FIL_RUNOUT2_PIN))
-      && ((powerloss.P_file_name[0] && powerloss.recovery == Rec_Idle) && print_job_timer.isRunning())
-      || !test
+      && ((powerloss.P_file_name[0] && powerloss.recovery == Rec_Idle && print_job_timer.isRunning()) || !test)
     ) {
       test = true;
       //buzzer.tone(400, 5000);

--- a/A20_Marlin-1.1.x12864/Marlin/Conditionals_LCD.h
+++ b/A20_Marlin-1.1.x12864/Marlin/Conditionals_LCD.h
@@ -28,6 +28,9 @@
 #ifndef CONDITIONALS_LCD_H // Get the LCD defines which are needed first
 #define CONDITIONALS_LCD_H
 
+  // Geeetech doesn't use this
+  #undef FILAMENT_RUNOUT_SENSOR
+
   #define LCD_HAS_DIRECTIONAL_BUTTONS (BUTTON_EXISTS(UP) || BUTTON_EXISTS(DWN) || BUTTON_EXISTS(LFT) || BUTTON_EXISTS(RT))
 
   #if ENABLED(CARTESIO_UI)

--- a/A20_Marlin-1.1.x12864/Marlin/stepper.cpp
+++ b/A20_Marlin-1.1.x12864/Marlin/stepper.cpp
@@ -408,11 +408,13 @@ ISR(TIMER1_COMPA_vect) {
     powerloss.pos_t = card.getStatus();
     powerloss.T0_t = thermalManager.degTargetHotend(0) + 0.5;
     powerloss.B_t = thermalManager.degTargetBed() + 0.5;
-    #if ENABLED(BLTOUCH)
-      powerloss.recovery = Rec_Idle;
-    #else
-      powerloss.recovery = Rec_Outage;
-    #endif
+    powerloss.recovery =
+      #if ENABLED(BLTOUCH)
+        Rec_Idle
+      #else
+        Rec_Outage
+      #endif
+    ;
     //settings.save();
     (void)settings.poweroff_save();
     settings.load();

--- a/A20_Marlin-1.1.x12864/Marlin/stepper.cpp
+++ b/A20_Marlin-1.1.x12864/Marlin/stepper.cpp
@@ -381,8 +381,7 @@ ISR(TIMER1_COMPA_vect) {
   //if (READ(FIL_RUNOUT_PIN) && powerloss.P_file_name[0] && powerloss.recovery == Rec_Idle && print_job_timer.isRunning()) {
   if (filament_runout_enabled) {
     if ( (READ(FIL_RUNOUT_PIN) || READ(FIL_RUNOUT2_PIN))
-      && ((powerloss.P_file_name[0] && powerloss.recovery == Rec_Idle) && print_job_timer.isRunning())
-      || !test
+      && ((powerloss.P_file_name[0] && powerloss.recovery == Rec_Idle && print_job_timer.isRunning()) || !test)
     ) {
       test = true;
       //buzzer.tone(400, 5000);

--- a/MeCreator2_marlin1.1.8/Marlin/Conditionals_LCD.h
+++ b/MeCreator2_marlin1.1.8/Marlin/Conditionals_LCD.h
@@ -28,6 +28,9 @@
 #ifndef CONDITIONALS_LCD_H // Get the LCD defines which are needed first
 #define CONDITIONALS_LCD_H
 
+  // Geeetech doesn't use this
+  #undef FILAMENT_RUNOUT_SENSOR
+
   #define LCD_HAS_DIRECTIONAL_BUTTONS (BUTTON_EXISTS(UP) || BUTTON_EXISTS(DWN) || BUTTON_EXISTS(LFT) || BUTTON_EXISTS(RT))
 
   #if ENABLED(CARTESIO_UI)


### PR DESCRIPTION
This PR addresses the blank screen problem which occurs whenever the filament sensor is enabled. 

A more comprehensive update of the filament sensor code (extending the `FILAMENT_RUNOUT_SENSOR` feature) will be provided in the near future to prevent LCD updates being applied from the stepper ISR. But for now this fixes a bug caused by a single missing parenthesis.

Also:
- Force `FILAMENT_RUNOUT_SENSOR` to be disabled to ensure there are no conflicts with the Geeetech implementation.