### PR TITLE
Fix error of Buzzer.h not found

### DIFF
--- a/A10D_marlin1.1.8/Marlin/stepper.cpp
+++ b/A10D_marlin1.1.8/Marlin/stepper.cpp
@@ -54,7 +54,7 @@
 #include "cardreader.h"
 #include "speed_lookuptable.h"
 #include "configuration_store.h"
-#include "Buzzer.h"
+#include "buzzer.h"
 
 extern Buzzer buzzer;
 

--- a/A10M_marlin1.1.8/Marlin/stepper.cpp
+++ b/A10M_marlin1.1.8/Marlin/stepper.cpp
@@ -54,7 +54,7 @@
 #include "cardreader.h"
 #include "speed_lookuptable.h"
 #include "configuration_store.h"
-#include "Buzzer.h"
+#include "buzzer.h"
 
 extern Buzzer buzzer;
 

--- a/A10M_marlin1.1.8_3Dtouch/Marlin/stepper.cpp
+++ b/A10M_marlin1.1.8_3Dtouch/Marlin/stepper.cpp
@@ -54,7 +54,7 @@
 #include "cardreader.h"
 #include "speed_lookuptable.h"
 #include "configuration_store.h"
-#include "Buzzer.h"
+#include "buzzer.h"
 
 extern Buzzer buzzer;
 

--- a/A10_marlin1.1.8/Marlin/stepper.cpp
+++ b/A10_marlin1.1.8/Marlin/stepper.cpp
@@ -54,7 +54,7 @@
 #include "cardreader.h"
 #include "speed_lookuptable.h"
 #include "configuration_store.h"
-#include "Buzzer.h"
+#include "buzzer.h"
 
 extern Buzzer buzzer;
 

--- a/A10_marlin1.1.8_3DTtouch/Marlin/stepper.cpp
+++ b/A10_marlin1.1.8_3DTtouch/Marlin/stepper.cpp
@@ -54,7 +54,7 @@
 #include "cardreader.h"
 #include "speed_lookuptable.h"
 #include "configuration_store.h"
-#include "Buzzer.h"
+#include "buzzer.h"
 
 extern Buzzer buzzer;
 

--- a/A20M_Marlin-1.1.x12864/Marlin/stepper.cpp
+++ b/A20M_Marlin-1.1.x12864/Marlin/stepper.cpp
@@ -54,7 +54,7 @@
 #include "cardreader.h"
 #include "speed_lookuptable.h"
 #include "configuration_store.h"
-#include "Buzzer.h"
+#include "buzzer.h"
 
 extern Buzzer buzzer;
 

--- a/A20M_Marlin-1.1.x12864_3DTouch/Marlin/stepper.cpp
+++ b/A20M_Marlin-1.1.x12864_3DTouch/Marlin/stepper.cpp
@@ -54,7 +54,7 @@
 #include "cardreader.h"
 #include "speed_lookuptable.h"
 #include "configuration_store.h"
-#include "Buzzer.h"
+#include "buzzer.h"
 
 extern Buzzer buzzer;
 

--- a/A20_Marlin-1.1.x12864/Marlin/stepper.cpp
+++ b/A20_Marlin-1.1.x12864/Marlin/stepper.cpp
@@ -54,7 +54,7 @@
 #include "cardreader.h"
 #include "speed_lookuptable.h"
 #include "configuration_store.h"
-#include "Buzzer.h"
+#include "buzzer.h"
 
 extern Buzzer buzzer;
 

--- a/A20_Marlin-1.1.x12864_3DTouch/Marlin/stepper.cpp
+++ b/A20_Marlin-1.1.x12864_3DTouch/Marlin/stepper.cpp
@@ -54,7 +54,7 @@
 #include "cardreader.h"
 #include "speed_lookuptable.h"
 #include "configuration_store.h"
-#include "Buzzer.h"
+#include "buzzer.h"
 
 extern Buzzer buzzer;
 


### PR DESCRIPTION
Fixes #14. Only tested for A10M folder; But other folders should work exactly the same.