### PR TITLE
Fix to be able to set z-offset to negative value with M851

### DIFF
--- a/I3pro/Firmware_Marlin/I3proW/Marlin/Configuration.h
+++ b/I3pro/Firmware_Marlin/I3proW/Marlin/Configuration.h
@@ -506,7 +506,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = false; // set to true to invert the logic o
 #ifdef CUSTOM_M_CODES
   #define CUSTOM_M_CODE_SET_Z_PROBE_OFFSET 851
   #define Z_PROBE_OFFSET_RANGE_MIN -15
-  #define Z_PROBE_OFFSET_RANGE_MAX -5
+  #define Z_PROBE_OFFSET_RANGE_MAX 15
 #endif
 
 


### PR DESCRIPTION
Changed Z_PROBE_OFFSET_RANGE_MAX to positive value to be able to adjust z offset with M851 code. Without this change, I can't set the negative z offset (-1.39) in the EEPROM using M851 for my printer with 3D Touch. Now I am able to do all steps documented in the geeetech wiki http://www.geeetech.com/wiki/index.php/3DTouch_Auto_Leveling_Sensor